### PR TITLE
add middle button fullscreen hotkey to follow original MPC-HC behaviour

### DIFF
--- a/input.conf
+++ b/input.conf
@@ -8,6 +8,7 @@ SPACE cycle pause  				 #pause/unpause
 MBTN_LEFT cycle pause    #pause/unpause (with left click)
 Alt+ENTER cycle fullscreen    #fullscreen/un-fullscreen (with double left click)
 MBTN_LEFT_DBL cycle fullscreen  #fullscreen/un-fullscreen
+MBTN_MID cycle fullscreen
 Alt+x quit-watch-later			 #quit and save position
 1 cycle border 		#Cycle between no titlebar/ "View Minimal in mpc-hc"
 Ctrl+a     cycle ontop     # keep mpv window on top of others


### PR DESCRIPTION
Original MPC-HC had this hotkey, i guess it is a good idea to add that.